### PR TITLE
Add modern neumorphic redesign with theme toggle

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -208,8 +208,10 @@ const snippetSources = [
 ];
 
 const storageKey = 'seo-checklist-state-v1';
+const themeStorageKey = 'seo-checklist-theme';
 
 document.addEventListener('DOMContentLoaded', () => {
+  initThemeToggle();
   renderChecklist();
   setupControls();
   loadSnippets();
@@ -383,6 +385,76 @@ function setupControls() {
       exportChecklist();
     });
   });
+}
+
+function initThemeToggle() {
+  const toggleButton = document.querySelector('[data-action="toggle-theme"]');
+  if (!toggleButton) {
+    return;
+  }
+
+  const storedTheme = readStoredTheme();
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+  const initialTheme = storedTheme || (prefersDark.matches ? 'dark' : 'light');
+
+  applyTheme(initialTheme);
+
+  const handlePreferenceChange = (event) => {
+    if (!readStoredTheme()) {
+      applyTheme(event.matches ? 'dark' : 'light');
+    }
+  };
+
+  if (typeof prefersDark.addEventListener === 'function') {
+    prefersDark.addEventListener('change', handlePreferenceChange);
+  } else if (typeof prefersDark.addListener === 'function') {
+    prefersDark.addListener(handlePreferenceChange);
+  }
+
+  toggleButton.addEventListener('click', () => {
+    const nextTheme = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+    applyTheme(nextTheme, true);
+  });
+}
+
+function applyTheme(theme, persist = false) {
+  document.documentElement.dataset.theme = theme;
+  document.body.dataset.theme = theme;
+
+  const toggleButton = document.querySelector('[data-action="toggle-theme"]');
+  if (toggleButton) {
+    toggleButton.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    toggleButton.setAttribute(
+      'title',
+      theme === 'dark' ? 'Wechsle zu Light Mode' : 'Wechsle zu Dark Mode'
+    );
+
+    const label = toggleButton.querySelector('[data-theme-label]');
+    if (label) {
+      label.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+    }
+  }
+
+  if (persist) {
+    writeStoredTheme(theme);
+  }
+}
+
+function readStoredTheme() {
+  try {
+    return window.localStorage.getItem(themeStorageKey);
+  } catch (error) {
+    console.error('Konnte Theme nicht lesen', error);
+    return null;
+  }
+}
+
+function writeStoredTheme(theme) {
+  try {
+    window.localStorage.setItem(themeStorageKey, theme);
+  } catch (error) {
+    console.error('Konnte Theme nicht speichern', error);
+  }
 }
 
 function exportChecklist() {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,167 +1,491 @@
 :root {
-  color-scheme: light dark;
-  --bg: #f5f7fa;
-  --card: #ffffff;
-  --text: #1a1c1f;
-  --accent: #0f62fe;
-  --accent-dark: #0043ce;
-  --border: #d6d9df;
+  color-scheme: light;
+  --bg: #edf1fb;
+  --bg-gradient: radial-gradient(circle at 15% 20%, rgba(79, 70, 229, 0.12), transparent 50%),
+    radial-gradient(circle at 85% 15%, rgba(14, 165, 233, 0.14), transparent 55%),
+    radial-gradient(circle at 50% 100%, rgba(56, 189, 248, 0.08), transparent 60%),
+    #edf1fb;
+  --card: rgba(255, 255, 255, 0.82);
+  --card-solid: #ffffff;
+  --card-elevated: rgba(255, 255, 255, 0.92);
+  --card-subtle: rgba(255, 255, 255, 0.65);
+  --text-primary: #0f172a;
+  --text-secondary: #1f2937;
+  --muted: #4b5563;
+  --border: rgba(148, 163, 184, 0.35);
+  --border-strong: rgba(100, 116, 139, 0.5);
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
   --success: #0e8a00;
-  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  --code-bg: #0f172a;
+  --code-text: #e2e8f0;
+  --control-bg: rgba(255, 255, 255, 0.72);
+  --control-border: rgba(148, 163, 184, 0.35);
+  --progress-bg: rgba(255, 255, 255, 0.72);
+  --progress-text: #1f2937;
+  --shadow-subtle: inset -2px -2px 4px rgba(255, 255, 255, 0.7), inset 2px 2px 4px rgba(15, 23, 42, 0.08);
+  --shadow-hover: -8px -8px 18px rgba(255, 255, 255, 0.8), 10px 10px 24px rgba(15, 23, 42, 0.18);
+  --shadow-soft: -18px -18px 36px rgba(255, 255, 255, 0.95), 20px 20px 48px rgba(15, 23, 42, 0.18);
+  --shadow-strong: -24px -24px 48px rgba(255, 255, 255, 1), 26px 26px 60px rgba(15, 23, 42, 0.2);
+  --toggle-track: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.92));
+  --toggle-thumb: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(214, 226, 242, 0.98));
+  --thumb-shadow: -3px -3px 6px rgba(255, 255, 255, 0.45), 3px 3px 6px rgba(15, 23, 42, 0.18);
+  --link: #2563eb;
+  --selection-bg: rgba(37, 99, 235, 0.2);
+  font-family: 'Manrope', 'Inter', 'Helvetica Neue', Arial, sans-serif;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #050917;
+  --bg-gradient: radial-gradient(circle at 10% 10%, rgba(76, 29, 149, 0.28), transparent 55%),
+    radial-gradient(circle at 80% -10%, rgba(14, 165, 233, 0.28), transparent 60%),
+    radial-gradient(circle at 50% 120%, rgba(59, 130, 246, 0.22), transparent 65%),
+    #050917;
+  --card: rgba(15, 23, 42, 0.88);
+  --card-solid: #0f172a;
+  --card-elevated: rgba(15, 23, 42, 0.94);
+  --card-subtle: rgba(30, 41, 59, 0.65);
+  --text-primary: #f8fafc;
+  --text-secondary: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(100, 116, 139, 0.4);
+  --border-strong: rgba(148, 163, 184, 0.6);
+  --accent: #60a5fa;
+  --accent-dark: #3b82f6;
+  --success: #34d399;
+  --code-bg: #020617;
+  --code-text: #f8fafc;
+  --control-bg: rgba(15, 23, 42, 0.75);
+  --control-border: rgba(71, 85, 105, 0.55);
+  --progress-bg: rgba(15, 23, 42, 0.75);
+  --progress-text: #e2e8f0;
+  --shadow-subtle: inset -2px -2px 4px rgba(148, 163, 184, 0.25), inset 3px 3px 6px rgba(2, 6, 23, 0.85);
+  --shadow-hover: -12px -12px 26px rgba(15, 23, 42, 0.85), 14px 14px 32px rgba(2, 6, 23, 0.88);
+  --shadow-soft: -18px -18px 36px rgba(15, 23, 42, 0.9), 22px 22px 48px rgba(2, 6, 23, 0.95);
+  --shadow-strong: -26px -26px 52px rgba(15, 23, 42, 0.92), 28px 28px 62px rgba(2, 6, 23, 0.96);
+  --toggle-track: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.95));
+  --toggle-thumb: linear-gradient(145deg, rgba(96, 165, 250, 0.95), rgba(37, 99, 235, 0.95));
+  --thumb-shadow: -3px -3px 6px rgba(90, 114, 152, 0.32), 3px 3px 6px rgba(2, 6, 23, 0.88);
+  --link: #60a5fa;
+  --selection-bg: rgba(96, 165, 250, 0.35);
 }
 
 * {
   box-sizing: border-box;
 }
 
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  line-height: 1.55;
+::selection {
+  background: var(--selection-bg);
 }
 
-.page-header,
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background 0.6s ease, color 0.6s ease;
+}
+
+body,
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
+a {
+  color: var(--link);
+}
+
+a:hover,
+a:focus {
+  text-decoration: none;
+}
+
 main,
+.page-header,
 .page-footer {
-  max-width: 960px;
+  width: min(1100px, 100%);
   margin: 0 auto;
-  padding: 1.5rem 1.25rem;
 }
 
 .page-header {
-  text-align: left;
+  margin-top: clamp(2rem, 5vw, 3.5rem);
+  padding: clamp(1.75rem, 2vw + 1.4rem, 3rem);
+  background: var(--card);
+  border-radius: 1.9rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(22px);
+  transition: background 0.5s ease, border 0.5s ease, box-shadow 0.5s ease;
+}
+
+.page-header::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 10%, rgba(37, 99, 235, 0.15), transparent 55%),
+    radial-gradient(circle at 90% 15%, rgba(14, 165, 233, 0.12), transparent 60%);
+  pointer-events: none;
+}
+
+.header-top {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  flex-wrap: wrap;
+  z-index: 1;
+}
+
+.title-group {
+  max-width: 640px;
 }
 
 .page-header h1 {
-  margin-bottom: 0.5rem;
-  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  margin: 0 0 0.75rem 0;
+  font-size: clamp(1.9rem, 3vw + 1.5rem, 2.9rem);
+  line-height: 1.12;
+  letter-spacing: -0.02em;
 }
 
 .intro {
-  margin: 0 0 1rem 0;
-  font-size: 1rem;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 0.8vw + 0.95rem, 1.1rem);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.4rem 0.85rem 0.4rem 0.45rem;
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 999px;
+  box-shadow: var(--shadow-subtle);
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  color: var(--text-primary);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border 0.3s ease, background 0.3s ease;
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-hover);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.toggle-track {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 56px;
+  height: 30px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--toggle-track);
+  box-shadow: inset -2px -2px 5px rgba(255, 255, 255, 0.2), inset 2px 2px 6px rgba(15, 23, 42, 0.15);
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 50%;
+  left: 6px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--toggle-thumb);
+  box-shadow: var(--thumb-shadow);
+  transform: translate(0, -50%);
+  transition: transform 0.35s ease, background 0.35s ease, box-shadow 0.35s ease;
+}
+
+:root[data-theme='dark'] .toggle-thumb {
+  transform: translate(26px, -50%);
+}
+
+.toggle-icon {
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.toggle-icon-sun {
+  color: #f59e0b;
+}
+
+.toggle-icon-moon {
+  color: #6366f1;
+}
+
+:root[data-theme='dark'] .toggle-icon-sun {
+  opacity: 0.55;
+}
+
+:root[data-theme='dark'] .toggle-icon-moon {
+  color: #facc15;
+}
+
+.toggle-text {
+  display: grid;
+  align-items: start;
+  gap: 0.15rem;
+  text-align: left;
+}
+
+.toggle-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.toggle-caption {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.control-panel {
+  margin-top: clamp(1.75rem, 3vw, 2.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  padding: clamp(0.9rem, 1.2vw + 0.6rem, 1.4rem);
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 1.25rem;
+  box-shadow: var(--shadow-subtle);
+  backdrop-filter: blur(18px);
+  position: relative;
+  z-index: 1;
 }
 
 .control-group {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  gap: 0.6rem;
 }
 
 .control-button {
-  border: 1px solid var(--border);
-  background: var(--card);
-  color: var(--text);
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid var(--control-border);
+  background: var(--card-solid);
+  color: var(--text-primary);
+  padding: 0.6rem 1.15rem;
+  border-radius: 0.95rem;
   font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
+  box-shadow: var(--shadow-subtle);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border 0.25s ease, background 0.25s ease;
 }
 
 .control-button:hover,
 .control-button:focus {
-  background: #e6f0ff;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-hover);
+  background: var(--card-elevated);
+}
+
+.control-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .control-button.primary {
-  background: var(--accent);
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
   color: #fff;
-  border-color: transparent;
+  border: none;
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.22);
+}
+
+:root[data-theme='dark'] .control-button.primary {
+  box-shadow: 0 18px 36px rgba(96, 165, 250, 0.25);
 }
 
 .control-button.primary:hover,
 .control-button.primary:focus {
-  background: var(--accent-dark);
+  transform: translateY(-2px);
+  filter: brightness(1.05);
 }
 
 .progress {
-  font-weight: 600;
   margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  background: var(--progress-bg);
+  color: var(--progress-text);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: var(--shadow-subtle);
+  border: 1px solid var(--control-border);
+}
+
+.progress::before {
+  content: '';
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.16);
+}
+
+main {
+  margin-top: clamp(2.5rem, 5vw, 3.5rem);
+  padding: 0 clamp(1.25rem, 4vw, 2.5rem) clamp(3rem, 6vw, 4.5rem);
+  display: grid;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
 }
 
 .checklist {
   display: grid;
-  gap: 1rem;
+  gap: clamp(1.25rem, 2.5vw, 1.85rem);
 }
 
 .category {
   border: 1px solid var(--border);
-  border-radius: 1rem;
+  border-radius: 1.6rem;
   background: var(--card);
-  box-shadow: 0 6px 24px rgba(15, 33, 55, 0.08);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
   overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border 0.3s ease;
+}
+
+.category:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-strong);
+}
+
+details[open].category {
+  border-color: var(--border-strong);
 }
 
 .category summary {
   list-style: none;
-  padding: 1rem 1.25rem;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
+  gap: 1rem;
+  padding: clamp(1.35rem, 1.5vw + 1rem, 1.85rem) clamp(1.5rem, 4vw, 2.2rem);
   cursor: pointer;
-  font-weight: 600;
-  font-size: 1.05rem;
+  position: relative;
+  font-weight: 700;
+  font-size: clamp(1.05rem, 0.9vw + 1rem, 1.25rem);
+  color: var(--text-primary);
+  transition: color 0.3s ease;
 }
 
 .category summary::-webkit-details-marker {
   display: none;
 }
 
-.category summary span {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: #4b5563;
+.category summary::after {
+  content: '';
+  position: absolute;
+  right: clamp(1.4rem, 3vw, 2.4rem);
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: translateY(-50%) rotate(-45deg);
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+details[open] > summary::after {
+  transform: translateY(-50%) rotate(135deg);
+  border-color: var(--accent);
+}
+
+.category-progress {
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  color: var(--muted);
+  box-shadow: var(--shadow-subtle);
 }
 
 .task-list {
   margin: 0;
-  padding: 0 1.25rem 1.25rem;
+  padding: 0 clamp(1.5rem, 4vw, 2.2rem) clamp(1.6rem, 4vw, 2.2rem);
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .task {
   display: grid;
-  gap: 0.25rem;
-  padding: 0.75rem 0.5rem;
-  border-bottom: 1px solid var(--border);
+  gap: 0.45rem;
+  padding: 1rem clamp(0.9rem, 3vw, 1.35rem);
+  border-radius: 1.1rem;
+  background: var(--card-subtle);
+  border: 1px solid transparent;
+  transition: background 0.3s ease, border 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
 }
 
-.task:last-child {
-  border-bottom: none;
+.task:hover {
+  box-shadow: var(--shadow-subtle);
 }
 
 .task label {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.8rem;
   font-weight: 600;
+  color: var(--text-secondary);
 }
 
-.task label input[type="checkbox"] {
-  margin-top: 0.2rem;
-  width: 1.15rem;
-  height: 1.15rem;
+.task label input[type='checkbox'] {
+  margin: 0;
+  width: 1.1rem;
+  height: 1.1rem;
   accent-color: var(--accent);
+  cursor: pointer;
 }
 
 .task .task-info {
-  margin-left: 2.1rem;
+  margin-left: calc(1.1rem + 0.8rem);
   display: grid;
-  gap: 0.25rem;
+  gap: 0.3rem;
+  color: var(--muted);
 }
 
-.task .webflow-path,
-.task .example {
-  font-size: 0.9rem;
-  color: #374151;
+.task .task-info p {
+  margin: 0;
+  font-size: 0.92rem;
 }
 
 .task.completed {
-  background: linear-gradient(90deg, rgba(14, 138, 0, 0.08), transparent);
+  background: linear-gradient(135deg, rgba(14, 138, 0, 0.18), transparent);
+  border-color: rgba(14, 138, 0, 0.35);
+  box-shadow: 0 18px 28px rgba(14, 138, 0, 0.18);
+  transform: translateY(-2px);
 }
 
 .task.completed label {
@@ -169,26 +493,46 @@ main,
 }
 
 .snippets {
-  margin-top: 2rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 1.7rem;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
+  padding: clamp(1.8rem, 4vw, 2.7rem);
+  transition: background 0.4s ease, border 0.4s ease, box-shadow 0.4s ease;
 }
 
 .snippets h2 {
-  font-size: 1.5rem;
-  margin-bottom: 0.5rem;
+  font-size: clamp(1.45rem, 1vw + 1.3rem, 1.9rem);
+  margin: 0 0 0.6rem 0;
+}
+
+.snippets p {
+  margin: 0 0 1.6rem 0;
+  color: var(--muted);
+  font-size: 1rem;
 }
 
 .snippet-grid {
   display: grid;
-  gap: 1rem;
+  gap: clamp(1.1rem, 2vw, 1.6rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .snippet-card {
   border: 1px solid var(--border);
-  border-radius: 1rem;
-  background: var(--card);
-  padding: 1rem;
+  border-radius: 1.25rem;
+  background: var(--card-elevated);
+  padding: clamp(1.1rem, 2vw, 1.45rem);
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
+  box-shadow: var(--shadow-subtle);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border 0.3s ease;
+}
+
+.snippet-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-hover);
 }
 
 .snippet-card header {
@@ -204,35 +548,70 @@ main,
 }
 
 .copy-button {
-  border: 1px solid var(--accent);
-  background: transparent;
+  border: 1px solid transparent;
+  background: rgba(37, 99, 235, 0.12);
   color: var(--accent);
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.6rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.75rem;
   font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   cursor: pointer;
+  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .copy-button:hover,
 .copy-button:focus {
-  background: rgba(15, 98, 254, 0.1);
+  background: rgba(37, 99, 235, 0.22);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+.copy-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .snippet-content {
-  background: #0f172a;
-  color: #e2e8f0;
-  padding: 0.75rem;
-  border-radius: 0.75rem;
+  background: var(--code-bg);
+  color: var(--code-text);
+  padding: 1rem;
+  border-radius: 1rem;
   overflow-x: auto;
   font-family: 'Fira Code', Consolas, 'Courier New', monospace;
   font-size: 0.85rem;
-  line-height: 1.4;
+  line-height: 1.45;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
 }
 
 .page-footer {
-  font-size: 0.85rem;
-  color: #4b5563;
+  margin-top: clamp(2.5rem, 6vw, 3.5rem);
+  padding: 0 clamp(1.25rem, 4vw, 2.5rem) clamp(3rem, 6vw, 4rem);
+  font-size: 0.9rem;
+  color: var(--muted);
   text-align: left;
+}
+
+@media (max-width: 900px) {
+  .header-top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .theme-toggle {
+    align-self: flex-start;
+  }
+
+  .control-panel {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .progress {
+    align-self: flex-start;
+  }
 }
 
 @media (max-width: 640px) {
@@ -245,11 +624,26 @@ main,
     width: 100%;
   }
 
-  .task label {
-    align-items: center;
+  .task {
+    padding: 1rem;
   }
 
   .task .task-info {
-    margin-left: 1.9rem;
+    margin-left: 0;
+  }
+
+  .toggle-caption {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,23 +1,55 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" data-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SEO &amp; GEO Checkliste für Webflow</title>
   <meta name="description" content="Praktische Checkliste für SEO, GEO und AI-Optimierung in Webflow. Mit Speicher, Export und Snippets für die Schweiz.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script>
+    (function () {
+      try {
+        var savedTheme = localStorage.getItem('seo-checklist-theme');
+        if (savedTheme) {
+          document.documentElement.dataset.theme = savedTheme;
+        }
+      } catch (error) {
+        /* localStorage nicht verfügbar */
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
   <header class="page-header">
-    <h1>SEO &amp; GEO Checkliste für Webflow</h1>
-    <p class="intro">Arbeite Schritt für Schritt. Setze Häkchen, lade Code-Snippets und exportiere die Liste für dein Team.</p>
-    <div class="control-group" aria-label="Checklistenaktionen">
-      <button type="button" class="control-button" data-action="open-all">Alle öffnen</button>
-      <button type="button" class="control-button" data-action="close-all">Alle schliessen</button>
-      <button type="button" class="control-button" data-action="reset">Reset</button>
-      <button type="button" class="control-button primary" data-action="export">Checkliste als CSV exportieren</button>
+    <div class="header-top">
+      <div class="title-group">
+        <h1>SEO &amp; GEO Checkliste für Webflow</h1>
+        <p class="intro">Arbeite Schritt für Schritt. Setze Häkchen, lade Code-Snippets und exportiere die Liste für dein Team.</p>
+      </div>
+      <button type="button" class="theme-toggle" data-action="toggle-theme" aria-pressed="false" aria-label="Darstellung umschalten">
+        <span class="toggle-track" aria-hidden="true">
+          <span class="toggle-thumb"></span>
+          <span class="toggle-icon toggle-icon-sun" aria-hidden="true">☀️</span>
+          <span class="toggle-icon toggle-icon-moon" aria-hidden="true">🌙</span>
+        </span>
+        <span class="toggle-text">
+          <span class="toggle-title" data-theme-label>Dark Mode</span>
+          <span class="toggle-caption">Wechsle den Look</span>
+        </span>
+      </button>
     </div>
-    <p class="progress" id="overall-progress" aria-live="polite"></p>
+    <div class="control-panel">
+      <div class="control-group" aria-label="Checklistenaktionen">
+        <button type="button" class="control-button" data-action="open-all">Alle öffnen</button>
+        <button type="button" class="control-button" data-action="close-all">Alle schliessen</button>
+        <button type="button" class="control-button" data-action="reset">Reset</button>
+        <button type="button" class="control-button primary" data-action="export">Checkliste als CSV exportieren</button>
+      </div>
+      <p class="progress" id="overall-progress" aria-live="polite"></p>
+    </div>
   </header>
 
   <main>


### PR DESCRIPTION
## Summary
- restyle the checklist shell with a neumorphic-inspired header, control panel, and snippet section
- add a dark/light mode toggle with persisted preference and inline theme bootstrapping
- refresh typography, shadows, and component states for a high-end visual polish

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb037f1f808327817a7dadbf670dc9