### PR TITLE
Fix checklist summary dropdown layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -386,12 +386,11 @@ details[open].category {
 .category summary {
   list-style: none;
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   align-items: center;
-  gap: 1rem;
-  padding: clamp(1.35rem, 1.5vw + 1rem, 1.85rem) clamp(1.5rem, 4vw, 2.2rem);
+  gap: clamp(0.75rem, 0.6vw + 0.7rem, 1rem);
+  padding: clamp(1.35rem, 1.5vw + 1rem, 1.85rem) clamp(1.8rem, 4vw, 2.6rem);
   cursor: pointer;
-  position: relative;
   font-weight: 700;
   font-size: clamp(1.05rem, 0.9vw + 1rem, 1.25rem);
   color: var(--text-primary);
@@ -404,19 +403,19 @@ details[open].category {
 
 .category summary::after {
   content: '';
-  position: absolute;
-  right: clamp(1.4rem, 3vw, 2.4rem);
-  top: 50%;
-  width: 12px;
-  height: 12px;
+  width: 0.75rem;
+  height: 0.75rem;
   border-right: 2px solid var(--muted);
   border-bottom: 2px solid var(--muted);
-  transform: translateY(-50%) rotate(-45deg);
+  transform: rotate(-45deg);
+  transform-origin: center;
   transition: transform 0.3s ease, border-color 0.3s ease;
+  justify-self: end;
+  align-self: center;
 }
 
 details[open] > summary::after {
-  transform: translateY(-50%) rotate(135deg);
+  transform: rotate(135deg);
   border-color: var(--accent);
 }
 


### PR DESCRIPTION
## Summary
- update the checklist summary grid to reserve dedicated space for the dropdown arrow
- reposition the summary arrow pseudo-element so it no longer overlaps the progress badge

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb0b2676008327b035861a8d0d7ec4