### PR TITLE
Add client persistence input and expand legal compliance checks

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -257,6 +257,56 @@ main,
   color: var(--muted);
 }
 
+.client-panel {
+  margin-top: clamp(1.75rem, 3vw, 2.5rem);
+  display: grid;
+  gap: 0.55rem;
+  padding: clamp(1rem, 1.6vw + 0.8rem, 1.6rem);
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 1.25rem;
+  box-shadow: var(--shadow-subtle);
+  backdrop-filter: blur(18px);
+  position: relative;
+  z-index: 1;
+}
+
+.client-panel label {
+  display: block;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.client-panel input[type='text'] {
+  width: 100%;
+  padding: 0.65rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--control-border);
+  background: var(--card-solid);
+  color: var(--text-primary);
+  font-size: 1rem;
+  box-shadow: var(--shadow-subtle);
+  transition: border 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.client-panel input[type='text']::placeholder {
+  color: var(--muted);
+}
+
+.client-panel input[type='text']:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+  box-shadow: var(--shadow-hover);
+}
+
+.client-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .control-panel {
   margin-top: clamp(1.75rem, 3vw, 2.5rem);
   display: flex;
@@ -341,6 +391,29 @@ main,
   letter-spacing: 0.02em;
   box-shadow: var(--shadow-subtle);
   border: 1px solid var(--control-border);
+}
+
+.status-group {
+  display: grid;
+  gap: 0.45rem;
+  align-items: start;
+  justify-items: start;
+}
+
+.client-progress {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.client-progress span {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.client-progress[data-state='empty'] span {
+  color: var(--muted);
+  font-weight: 500;
 }
 
 .progress::before {
@@ -606,6 +679,10 @@ details[open] > summary::after {
   .control-panel {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .status-group {
+    width: 100%;
   }
 
   .progress {

--- a/index.html
+++ b/index.html
@@ -41,6 +41,19 @@
         </span>
       </button>
     </div>
+    <div class="client-panel" aria-label="Kundennamen speichern">
+      <label for="client-name">Kunde / Projekt</label>
+      <input
+        type="text"
+        id="client-name"
+        name="client-name"
+        data-client-input
+        placeholder="z.B. Kauwerk Dental Visp"
+        autocomplete="off"
+        aria-describedby="client-hint"
+      >
+      <p class="client-hint" id="client-hint">Wird lokal gespeichert, bis du Reset klickst.</p>
+    </div>
     <div class="control-panel">
       <div class="control-group" aria-label="Checklistenaktionen">
         <button type="button" class="control-button" data-action="open-all">Alle öffnen</button>
@@ -48,7 +61,10 @@
         <button type="button" class="control-button" data-action="reset">Reset</button>
         <button type="button" class="control-button primary" data-action="export">Checkliste als CSV exportieren</button>
       </div>
-      <p class="progress" id="overall-progress" aria-live="polite"></p>
+      <div class="status-group">
+        <p class="progress" id="overall-progress" aria-live="polite"></p>
+        <p class="client-progress" aria-live="polite" data-state="empty">Kunde: <span data-client-output>Kein Kunde gesetzt</span></p>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- add a persistent client/project input field with status display in the header
- style the new client area and status indicators for the checklist overview
- extend the checklist with explicit tasks for privacy policy, imprint, and cookie consent

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb0e7c26408327a1faf13ee96dc908